### PR TITLE
make reference project runnable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12,8 +12,8 @@ from lightning.pytorch.trainer import Trainer
 from optuna.integration.pytorch_lightning import \
     PyTorchLightningPruningCallback
 
-from data.datamodule import SequentialNumberBase
-from model.linear import BaseClassifier
+from data.datamodule import BoringDataModule
+from model.base import BoringModel
 
 
 class MyTrainer(Trainer):
@@ -218,8 +218,8 @@ class EnhancedCli(LightningCLI):
 
 def get_cli() -> None:
     cli = EnhancedCli(
-        model_class=BaseClassifier, subclass_mode_model=True,
-        datamodule_class=SequentialNumberBase, subclass_mode_data=True,
+        model_class=BoringModel, subclass_mode_model=True,
+        datamodule_class=BoringDataModule, subclass_mode_data=True,
     )
 
 

--- a/configs/data_reference.yaml
+++ b/configs/data_reference.yaml
@@ -1,5 +1,5 @@
 class_path: data.datamodule.BoringDataModule
 init_args:
   batch_size: 32
-  size: 4
-  length: 32
+  size: 32
+  length: 128

--- a/configs/model_reference.yaml
+++ b/configs/model_reference.yaml
@@ -1,7 +1,7 @@
 class_path: model.base.BoringModel
 init_args:
   C: 10
-  latent_dim: 3
+  latent_dim: 32
   dropout: 0.2
   lr: 1e-3
   lr_restart: 4

--- a/data/datamodule.py
+++ b/data/datamodule.py
@@ -14,7 +14,7 @@ class BoringDataModule(L.LightningDataModule):
     valid_set: Dataset
     test_set: Dataset
     predict_set: Dataset
-    scaler: StandardScaler | RobustScaler | Normalizer
+    scaler: StandardScaler | RobustScaler | Normalizer = None
     
     def __init__(self, size: int, length: int, batch_size: int = 32 ,**kwargs) -> None:
         super().__init__()

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -13,7 +13,7 @@ class RandomDataset(Dataset):
         self.data = torch.randn(length, size)
 
     def __getitem__(self, index: int) -> Tensor:
-        return self.data[index]
+        return self.data[index], 0
 
     def __len__(self) -> int:
         return self.len

--- a/model/base.py
+++ b/model/base.py
@@ -72,7 +72,7 @@ class BoringModel(LightningModule):
     def validation_step(self, batch: torch.Tensor, batch_idx: int = None) -> STEP_OUTPUT:
         X, y_true = batch
         loss, y_pred = self.generic_step(X, y_true)
-        acc = accuracy(preds=y_pred, target=y_true)
+        acc = accuracy(preds=y_pred, target=y_true, task='multiclass', num_classes=self.hparams.C)
         self.log("hp/loss", loss)
         self.log("hp/acc", acc)
         self.log("valid/loss", loss)
@@ -82,7 +82,7 @@ class BoringModel(LightningModule):
     def test_step(self, batch: torch.Tensor, batch_idx: int = None) -> STEP_OUTPUT:
         X, y_true = batch
         loss, y_pred = self.generic_step(X, y_true)
-        acc = accuracy(preds=y_pred, target=y_true)
+        acc = accuracy(preds=y_pred, target=y_true, task='multiclass', num_classes=self.hparams.C)
         self.log("test/loss", loss)
         self.log("test/acc", acc)
         return loss

--- a/train.py
+++ b/train.py
@@ -1,7 +1,5 @@
-import os
-
 from cli import get_cli
+
 
 if __name__ == "__main__":
     get_cli()
-    os.system("shutdown -s -t 360") # shutdown in 60s


### PR DESCRIPTION
Instead of using dummy values, shapes and modules now use methods that can actually train.